### PR TITLE
Bump plugin version to 1.1.0

### DIFF
--- a/lsky-pro-uploader.php
+++ b/lsky-pro-uploader.php
@@ -3,7 +3,7 @@
 Plugin Name: LskyPro For WordPress
 Plugin URI: https://www.littlesheep.cc
 Description: 自动将WordPress上传的图片同步到LskyPro图床
-Version: 1.0.1
+Version: 1.1.0
 Author: LittleSheep
 Author URI: https://www.littlesheep.cc
 */

--- a/modules/admin.php
+++ b/modules/admin.php
@@ -92,14 +92,14 @@ function lsky_pro_admin_scripts($hook) {
             break;
 
         case 'lsky-pro-settings':
-            wp_enqueue_script('lsky-pro-admin-base', plugins_url('assets/js/admin/base.js', LSKY_PRO_PLUGIN_FILE), $base_deps, '1.0.1', true);
+            wp_enqueue_script('lsky-pro-admin-base', plugins_url('assets/js/admin/base.js', LSKY_PRO_PLUGIN_FILE), $base_deps, '1.1.0', true);
             wp_localize_script('lsky-pro-admin-base', 'lskyProData', array(
                 'nonce' => wp_create_nonce('lsky_pro_ajax'),
                 'batchNonce' => wp_create_nonce('lsky_pro_batch'),
                 'ajaxurl' => admin_url('admin-ajax.php')
             ));
-            wp_enqueue_script('lsky-pro-admin-info', plugins_url('assets/js/admin/info.js', LSKY_PRO_PLUGIN_FILE), array('lsky-pro-admin-base'), '1.0.1', true);
-            wp_enqueue_script('lsky-pro-admin-update', plugins_url('assets/js/admin/update.js', LSKY_PRO_PLUGIN_FILE), array('lsky-pro-admin-base'), '1.0.1', true);
+            wp_enqueue_script('lsky-pro-admin-info', plugins_url('assets/js/admin/info.js', LSKY_PRO_PLUGIN_FILE), array('lsky-pro-admin-base'), '1.1.0', true);
+            wp_enqueue_script('lsky-pro-admin-update', plugins_url('assets/js/admin/update.js', LSKY_PRO_PLUGIN_FILE), array('lsky-pro-admin-base'), '1.1.0', true);
             break;
 
         case 'lsky-pro-config':


### PR DESCRIPTION
### Motivation
- Update the plugin release version to reflect a new patch/feature release.
- Ensure enqueued admin script version strings are consistent with the plugin version for cache busting.

### Description
- Updated the plugin header `Version` in `lsky-pro-uploader.php` from `1.0.1` to `1.1.0`.
- Aligned admin script enqueue version strings in `modules/admin.php` for `lsky-pro-admin-base`, `lsky-pro-admin-info`, and `lsky-pro-admin-update` to `1.1.0`.

### Testing
- No automated tests were run for this change.
- Basic repository inspection and file updates were verified during the change process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d059967908328989308b8adc4c8e3)